### PR TITLE
[BUG FIX] - Fix autofocus when opening Omnibar

### DIFF
--- a/flow-editor/src/flow-editor/omnibar/Omnibar.tsx
+++ b/flow-editor/src/flow-editor/omnibar/Omnibar.tsx
@@ -58,7 +58,7 @@ export const Omnibar: React.FC<OmnibarProps> = (props) => {
   const {repo} = props;
 
   const [searchValue, setSearchValue] = React.useState("");
-  const [items, setItems] = React.useState<OmniBarItem[]>([]);
+  const [items, setItems] = React.useState<OmniBarItem[] | null>(null);
 
   const [importables, setImportables] = React.useState<ImportablePart[]>([]);
 
@@ -148,7 +148,7 @@ export const Omnibar: React.FC<OmnibarProps> = (props) => {
     props.onClose();
   }, [props]);
 
-  return (
+  return items ? (
     <ExternalOmnibar
       query={searchValue}
       onQueryChange={setSearchValue}
@@ -161,7 +161,6 @@ export const Omnibar: React.FC<OmnibarProps> = (props) => {
       onItemSelect={onSelect as any}
       itemRenderer={renderItem}
       inputProps={{placeholder: 'Search for parts or commands..'}}
-      
     />
-  );
+  ) : null;
 }


### PR DESCRIPTION
For some reason blueprintjs Omnibar wasn't liking the fact that the `items` change after the first render.
Fix was to make sure to only render the Omnibar after the initial construction of the omnibar items is complete.